### PR TITLE
fix for Toast page onclick event not working: M was not accessible from html onclick events

### DIFF
--- a/partials/head.html
+++ b/partials/head.html
@@ -28,3 +28,7 @@
   href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
   rel="stylesheet"
 />
+<script>
+  const theme = localStorage.getItem("theme");
+  if (theme) document.documentElement.setAttribute("theme", theme);
+</script>

--- a/partials/head.html
+++ b/partials/head.html
@@ -28,7 +28,3 @@
   href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
   rel="stylesheet"
 />
-<script>
-  const theme = localStorage.getItem("theme");
-  if (theme) document.documentElement.setAttribute("theme", theme);
-</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import "./style.scss";
 import "prismjs/themes/prism.min.css";
 import { config } from "../config.materialize";
 
+globalThis.M = M  
+
 document.addEventListener("DOMContentLoaded", function() {
   function rgb2hex(rgb: string) {
     if (/^#[0-9A-F]{6}$/i.test(rgb)) return rgb;

--- a/toasts.html
+++ b/toasts.html
@@ -20,7 +20,7 @@
               <button
                 type="button"
                 class="waves-effect waves-light btn"
-                onclick="M.toast({text: 'I am a toast'})"
+                onclick="M.toast({text: 'I am a toast', classes: 'primary'})"
               >
                 Toast!
               </button>


### PR DESCRIPTION
As commented [here](https://stackoverflow.com/q/44590393/19046), elements defined in modules cannot be directly used in html.
So this code was not working
```
<button onclick="M.toast({text: 'I am a toast'})">
```
I have added a global var M in head so it can be used from all pages.
With M can be used as a global as before.

This not affect to sites were materialize is imported as a regular js.
