### PR TITLE
feat(toast): property to specify an element as toast content instead …

### DIFF
--- a/toasts.html
+++ b/toasts.html
@@ -64,34 +64,12 @@
                     <td>The content of the Toast.</td>
                   </tr>
                   <tr>
-                    <td>unsafeHTML</td>
-                    <td>String, HTMLElement</td>
-                    <td>''</td>
-                    <td>
-                      HTML content that will be appended to to
-                      <code class="language-javascript">text</code>. Only use
-                      properly sanitized or otherwise trusted data for
-                      <code class="language-javascript">unsafeHTML</code>.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>html</td>
+                    <td>toastId</td>
                     <td>String</td>
                     <td>''</td>
                     <td>
                       <p>
-                        (DEPRECATED): will be removed in a later release.
-                      </p>
-                      <p>
-                        HTML content that will be appended to
-                        <code class="language-javascript">text</code>. Only use
-                        properly sanitized or otherwise trusted data for
-                        <code class="language-javascript">html</code>.
-                      </p>
-                      <p>
-                        Will be ignored if
-                        <code class="language-javascript">unsafeHTML</code> is
-                        set.
+                        Id of an HTML element that will be used as tootip content.
                       </p>
                     </td>
                   </tr>
@@ -180,27 +158,34 @@
             <div id="custom-html" class="section scrollspy">
               <h3 class="header">Custom HTML</h3>
               <p>
-                You can pass in an HTML String as the first argument as well.
-                Take a look at the example below, where we pass in text as well
-                as a flat button. If you call an external function instead of
-                in-line JavaScript, you will not need to escape quotation marks.
-              </p>
-              <p>
-                Only use a properly sanitized or otherwise trusted HTML string.
-              </p>
+                You can pass in an toastId as the argument as well.
+                This toastId should refer to some element in the HTML that will be used as toast content.
+              </p>              
               <button
-                type="button"
-                class="waves-effect waves-light btn"
-                onclick="displayCustomHTMLToast()"
-              >
-                Toast with Action
+                  type="button"
+                  class="waves-effect waves-light btn"
+                  onclick="M.toast({toastId: 'my-toast-1'})"
+                >Toast 1!
               </button>
-              <pre><code class="language-javascript">
-  var toastHTML = '&lt;span>I am toast content&lt;/span>&lt;button class="btn-flat toast-action">Undo&lt;/button>';
-  M.toast({unsafeHTML: toastHTML});
-        </code></pre>
+              <div id="my-toast-1" style="display: none;">
+                  This is toast nº1 with a
+                  <a href="https://github.com/materializecss"> link </a>
+              </div>
+              <button
+                  type="button"
+                  class="waves-effect waves-light btn"
+                  onclick="M.toast({toastId: 'my-toast-2', classes: 'primary'})"
+                >Toast 2!
+              </button>
+              <div id="my-toast-2" style="display: none;">
+                  This is toast nº2 with a <i class="material-icons icon-demo">insert_chart</i>
+              </div>
+              <pre><code class="language-markup">
+<xmp><button type="button" class="btn" onclick="M.toast({toastId: 'my-toast-1'})">Toast 2!</button>
+<div id="my-toast-1" style="display: none;">
+  This is toast nº1 with a <a href="https://github.com/materializecss">link</a>
+</div></xmp></code></pre>
             </div>
-
             <div id="callback" class="scrollspy section">
               <h3 class="header">Callback</h3>
               <p>


### PR DESCRIPTION
## Proposed changes
Documentation update corresponding to https://github.com/materializecss/materialize/pull/436

Alternative solution to "[Bug]: Toast html/unsafeHtml not work #394 ". This will allow to specify some element as tooltip content. A new property `data-tooltip-id `will allow specify an element as tooltip content instead of text.

## Screenshots (if appropriate) or codepen:


will appear as (this also shows part of corresponding update in docs)

![imagen](https://github.com/materializecss/materialize/assets/80809/f8892b10-a1a4-4e79-9c18-ca684ffc3f70)



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [ x I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, ~and updated it accordingly~.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.