### PR TITLE
Using paths to avoid having "module": "src/index.ts" entry in package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "paths": {
-    "packages/*": ["packages/*"]
+    "@materializecss/materialize": ["packages/materialize"],
   },
   "include": ["src"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,12 @@ function getMenuItem(item) {
 
 export default {
   base: "./",
+  resolve: {
+    alias: {
+      '@materializecss/materialize/sass': path.resolve(__dirname, './packages/materialize/sass/'),   
+      '@materializecss/materialize': path.resolve(__dirname, './packages/materialize/src/')      
+    }    
+  },  
   plugins: [
     handlebars({
       context(pagePath) {


### PR DESCRIPTION
The "module": "src/index.ts" was used to work with the package as a workspace.
This was causing problems, for example 
https://github.com/materializecss/materialize/issues/455

Using paths in tsconfig and vite.config this "module": "src/index.ts" problematic entry is not needed anymore.