### PR TITLE
Theme color scheme selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@material/material-color-utilities": "^0.2.7",
     "@materializecss/materialize": "workspace:*",
     "glob": "^10.3.3",
     "material-icons": "^1.13.8",

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -126,7 +126,9 @@
   <div class="modal-content">
     <h4>Color Scheme</h4>
     <div>Primary Color: <input type="color" id="color-picker" value="#0000ff"></div>
-    
+    <button type="button" class="btn" onclick="downloadCss()">    
+      Download css style
+    </button>
   </div>
   <div class="modal-footer">
     <a href="#!" class="modal-close waves-effect btn-flat"

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,12 +1,11 @@
 <header>
-  <div class="search-results card"></div>
+    <div class="search-results card"></div>
 
-  <!-- Top Nav -->
-  <div class="navbar-fixed">
-    <nav class="primary">
-      <div class="nav-wrapper">
-        <a class="sidenav-trigger" href="#" data-target="nav-mobile"
-          ><i class="material-icons">menu</i></a
+    <!-- Top Nav -->
+    <div class="navbar-fixed">
+        <nav class="primary">
+            <div class="nav-wrapper">
+                <a class="sidenav-trigger" href="#" data-target="nav-mobile"><i class="material-icons">menu</i></a
         >
 
         <ul>
@@ -17,10 +16,9 @@
           <li>
             <a id="select-palette" class="modal-trigger" href="#palette-selector">
               <i class="material-icons">palette</i>
-            </a>            
-          <li>            
-            <a id="theme-switch" href="#"
-              ><i class="material-icons">dark_mode</i></a
+            </a>
+                <li>
+                    <a id="theme-switch" href="#"><i class="material-icons">dark_mode</i></a
             >
           </li>
           <li>
@@ -31,30 +29,20 @@
               title="Check out our GitHub"
               ><img src="images/github.svg" style="transform: scale(0.8);"
             /></a>
-          </li>
-          <li>
-            <a
-              class="ext-link"
-              href="https://opencollective.com/materialize"
-              target="_blank"
-              title="Support us via OpenCollective"
-              ><img src="images/opencollective.svg"
-            /></a>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  </div>
+                </li>
+                <li>
+                    <a class="ext-link" href="https://opencollective.com/materialize" target="_blank" title="Support us via OpenCollective"><img src="images/opencollective.svg" /></a>
+                </li>
+                </ul>
+            </div>
+        </nav>
+    </div>
 
-  <!-- Sidenav -->
-  <ul class="sidenav sidenav-fixed" id="nav-mobile">
-    <li class="logo">
-      <a class="brand-logo" id="logo-container" href="/">
-        <object
-          id="front-page-logo"
-          type="image/svg+xml"
-          data="images/materialize.svg"
-          >Your browser does not support SVG</object
+    <!-- Sidenav -->
+    <ul class="sidenav sidenav-fixed" id="nav-mobile">
+        <li class="logo">
+            <a class="brand-logo" id="logo-container" href="/">
+                <object id="front-page-logo" type="image/svg+xml" data="images/materialize.svg">Your browser does not support SVG</object
         >Materialize</a
       >
     </li>
@@ -125,7 +113,10 @@
 <div id="palette-selector" class="modal">
   <div class="modal-content">
     <h4>Color Scheme</h4>
-    <div>Primary Color: <input type="color" id="color-picker" value="#0000ff"></div>
+    <div class="color-row">
+      <label>Primary Color</label>      
+      <input type="color" id="color-picker" value="#0000ff">
+    </div>
     <button type="button" class="btn" onclick="downloadCss()">    
       Download css style
     </button>

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -14,7 +14,8 @@
         </ul>
 
         <ul class="right">
-          <li>
+          <li><input type="color" id="color-picker" value="#0000ff"></li>            
+          <li>            
             <a id="theme-switch" href="#"
               ><i class="material-icons">dark_mode</i></a
             >

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -14,7 +14,10 @@
         </ul>
 
         <ul class="right">
-          <li><input type="color" id="color-picker" value="#0000ff"></li>            
+          <li>
+            <a id="select-palette" class="modal-trigger" href="#palette-selector">
+              <i class="material-icons">palette</i>
+            </a>            
           <li>            
             <a id="theme-switch" href="#"
               ><i class="material-icons">dark_mode</i></a
@@ -119,3 +122,15 @@
     </li>
   </ul>
 </header>
+<div id="palette-selector" class="modal">
+  <div class="modal-content">
+    <h4>Color Scheme</h4>
+    <div>Primary Color: <input type="color" id="color-picker" value="#0000ff"></div>
+    
+  </div>
+  <div class="modal-footer">
+    <a href="#!" class="modal-close waves-effect btn-flat"
+      >Close</a
+    >
+  </div>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@material/material-color-utilities':
+        specifier: ^0.2.7
+        version: 0.2.7
       '@materializecss/materialize':
         specifier: workspace:*
         version: link:packages/materialize
@@ -608,6 +611,10 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
+
+  /@material/material-color-utilities@0.2.7:
+    resolution: {integrity: sha512-0FCeqG6WvK4/Cc06F/xXMd/pv4FeisI0c1tUpBbfhA2n9Y8eZEv4Karjbmf2ZqQCPUWMrGp8A571tCjizxoTiQ==}
+    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}

--- a/src/css-generator.ts
+++ b/src/css-generator.ts
@@ -1,0 +1,109 @@
+import { Scheme, Theme, hexFromArgb } from "@material/material-color-utilities";
+
+export class CssGenerator {
+  constructor(private readonly theme: Theme) {}
+
+  tokens(): string[] {
+    const rgbHex = hexFromArgb(this.theme.palettes.primary.tone(40))  
+    const tones = [0, 10, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, 95, 98, 99, 100]  
+    return [
+      ':root {', 
+      `  --md-source: ${rgbHex};`,
+      '  /* primary */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-primary", tone, (n) => this.theme.palettes.primary.tone(n))),      
+      '  /* secondary */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-secondary", tone, (n) => this.theme.palettes.secondary.tone(n))),        
+      '  /* tertiary */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-tertiary", tone, (n) => this.theme.palettes.tertiary.tone(n))),        
+      '  /* neutral */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-neutral", tone, (n) => this.theme.palettes.neutral.tone(n))),        
+      '  /* neutral-variant */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-neutral-variant", tone, (n) => this.theme.palettes.neutralVariant.tone(n))),        
+      '  /* error */',
+      ...tones.map(tone => this.getPaletteNum("  --md-ref-palette-error", tone, (n) => this.theme.palettes.error.tone(n))),
+      ...this.cssModeColors('light', this.theme.schemes.light),
+      ...this.cssModeColors('dark', this.theme.schemes.dark),
+      ...this.fontStyles('display-large',  'Regular', '400px', '57px', '64px', '-0.25px'),
+      ...this.fontStyles('display-medium', 'Regular', '400px', '45px', '52px', '0px'),
+      ...this.fontStyles('display-small', 'Regular','400px', '36px', '44px', '0px'),
+      ...this.fontStyles('headline-large', 'Regular','400px', '32px', '40px', '0px'),
+      ...this.fontStyles('headline-medium', 'Regular','400px', '28px', '36px', '0px'),
+      ...this.fontStyles('headline-small', 'Regular','400px', '24px', '32px', '0px'),
+      ...this.fontStyles('body-large', 'Regular','400px', '16px', '24px', '0.50px'),
+      ...this.fontStyles('body-medium', 'Regular','400px', '14px', '20px', '0.25px'),
+      ...this.fontStyles('body-small', 'Regular','400px', '12px', '16px', '0.40px'),
+      ...this.fontStyles('label-large', 'Medium','500px', '14px', '20px', '0.10px'),
+      ...this.fontStyles('label-medium', 'Medium','500px', '12px', '16px', '0.50px'),
+      ...this.fontStyles('label-small', 'Medium','500px', '11px', '16px', '0.50px'),
+      ...this.fontStyles('title-large', 'Regular','400px', '22px', '28px', '0px'),
+      ...this.fontStyles('title-medium', 'Medium','500px', '16px', '24px', '0.15px'),
+      ...this.fontStyles('title-small', 'Medium','500px', '14px', '20px', '0.10px'),
+      "}"        
+    ]
+  
+    
+  }
+  
+  cssModeColors(mode: string, scheme: Scheme): string[] {
+    return [
+      `  /* ${mode} */`,
+      this.getRoleColor(mode, "--md-sys-color-primary", scheme.primary),
+      this.getRoleColor(mode, "--md-sys-color-on-primary", scheme.onPrimary),
+      this.getRoleColor(mode, "--md-sys-color-primary-container", scheme.primaryContainer),    
+      this.getRoleColor(mode, "--md-sys-color-on-primary-container", scheme.onPrimaryContainer),    
+      this.getRoleColor(mode, "--md-sys-color-secondary", scheme.secondary),
+      this.getRoleColor(mode, "--md-sys-color-on-secondary", scheme.onSecondary),
+      this.getRoleColor(mode, "--md-sys-color-secondary-container", scheme.secondaryContainer),
+      this.getRoleColor(mode, "--md-sys-color-on-secondary-container", scheme.onSecondaryContainer),
+      this.getRoleColor(mode, "--md-sys-color-tertiary", scheme.tertiary),
+      this.getRoleColor(mode, "--md-sys-color-on-tertiary", scheme.onTertiary),
+      this.getRoleColor(mode, "--md-sys-color-tertiary-container", scheme.tertiaryContainer),
+      this.getRoleColor(mode, "--md-sys-color-on-tertiary-container", scheme.onTertiaryContainer),
+      this.getRoleColor(mode, "--md-sys-color-error", scheme.error),
+      this.getRoleColor(mode, "--md-sys-color-error-container", scheme.errorContainer),
+      this.getRoleColor(mode, "--md-sys-color-on-error", scheme.onError),
+      this.getRoleColor(mode, "--md-sys-color-on-error-container", scheme.onErrorContainer),    
+      this.getRoleColor(mode, "--md-sys-color-background", scheme.background),
+      this.getRoleColor(mode, "--md-sys-color-on-background", scheme.onBackground),
+      this.getRoleColor(mode, "--md-sys-color-surface", scheme.surface),
+      this.getRoleColor(mode, "--md-sys-color-on-surface", scheme.onSurface),
+      this.getRoleColor(mode, "--md-sys-color-surface-variant", scheme.surfaceVariant),
+      this.getRoleColor(mode, "--md-sys-color-on-surface-variant", scheme.onSurfaceVariant),
+      this.getRoleColor(mode, "--md-sys-color-outline", scheme.outline),
+      this.getRoleColor(mode, "--md-sys-color-inverse-on-surface", scheme.inverseOnSurface),
+      this.getRoleColor(mode, "--md-sys-color-inverse-surface", scheme.inverseSurface),
+      this.getRoleColor(mode, "--md-sys-color-inverse-primary", scheme.inversePrimary),
+      this.getRoleColor(mode, "--md-sys-color-shadow", scheme.shadow),
+      this.getRoleColor(mode, "--md-sys-color-surface-tint", scheme.surface),
+      this.getRoleColor(mode, "--md-sys-color-outline-variant", scheme.outlineVariant),
+      this.getRoleColor(mode, "--md-sys-color-scrim", scheme.scrim),
+    ]
+  }
+  
+  getPaletteNum(prefix: string, num: number, toTone: (num) => number): string
+  {
+    const rgbHex =  hexFromArgb(toTone(num))  
+    return `${prefix}${num}: ${rgbHex};`
+  }
+  
+  getRoleColor(mode: string, description: string, tone: number): string
+  {
+    const rgbHex =  hexFromArgb(tone)  
+    return `  ${description}-${mode}: ${rgbHex};`
+  }
+  
+      
+  fontStyles(description: string, style: string, weight: string, size: string, lineHeight: string, letterSpacing: string): string[]
+  {
+    return  [`/* ${description} */`,
+    `  --md-sys-typescale-${description}-font-family-name: Roboto;`,
+    `  --md-sys-typescale-${description}-font-family-style: ${style};`,
+    `  --md-sys-typescale-${description}-font-weight: ${weight};`,
+    `  --md-sys-typescale-${description}-font-size: ${size};`,
+    `  --md-sys-typescale-${description}-line-height: ${lineHeight};`,
+    `  --md-sys-typescale-${description}-letter-spacing: ${letterSpacing};`] 
+  }
+      
+      
+     
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import Prism from "prismjs";
 import "./style.scss";
 import "prismjs/themes/prism.min.css";
 import { config } from "../config.materialize";
+import { argbFromHex, themeFromSourceColor, applyTheme } from "@material/material-color-utilities";
+import { setThemeProperties } from "./themes";
+
 
 globalThis.M = M  
 
@@ -178,6 +181,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Theme
   const theme = localStorage.getItem("theme");
+  const themeColor = localStorage.getItem('theme-color');
   const themeSwitch = document.querySelector("#theme-switch");
   const setTheme = (isDark) => {
     if (isDark) {
@@ -189,10 +193,37 @@ document.addEventListener("DOMContentLoaded", function() {
       themeSwitch.querySelector("i").innerText = "dark_mode";
       (themeSwitch as any).title = "Switch to dark mode";
     }
+    let themeColor = localStorage.getItem('theme-color');
+    if (!themeColor)
+      themeColor = "#006495"
+    const color = argbFromHex(themeColor)
+    
+    const atheme = themeFromSourceColor(color)
+    applyTheme(atheme, {target: document.body, dark: isDark, brightnessSuffix: true})
+    setThemeProperties(document.body)
   };
+  const setThemeColor = (colorStr) => {
+    localStorage.setItem('theme-color', colorStr)
+    const color = argbFromHex(colorStr)
+    
+    const atheme = themeFromSourceColor(color)
+    
+    // Print out the theme as JSON
+    console.log(JSON.stringify(atheme, null, 2))
+    
+    // Check if the user has dark mode turned on
+    //const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+    const theme = localStorage.getItem("theme");    
+    
+    // Apply the theme to the body by updating custom properties for material tokens
+    //applyTheme(atheme, {target: document.body, dark: true, brightnessSuffix: true})
+    applyTheme(atheme, {target: document.body, dark: theme != null, brightnessSuffix: true})
+    setThemeProperties(document.body)
+  }
   if (themeSwitch) {
     // Load
     if (theme) setTheme(true);
+    if (themeColor) setThemeColor(themeColor)
     // Change
     themeSwitch.addEventListener("click", (e) => {
       e.preventDefault();
@@ -209,6 +240,13 @@ document.addEventListener("DOMContentLoaded", function() {
       }
     });
   }
+  const toggleColorsButton = <HTMLInputElement> document.getElementById('color-picker');
+  if (toggleColorsButton && themeColor) {
+    toggleColorsButton.value = themeColor
+  }
+  toggleColorsButton?.addEventListener('change', () => {
+    setThemeColor(toggleColorsButton.value)
+  });
 
   // Copy Button
   const copyBtn = Array.prototype.slice.call(

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,10 @@ import "./style.scss";
 import "prismjs/themes/prism.min.css";
 import { config } from "../config.materialize";
 import { argbFromHex, themeFromSourceColor, applyTheme } from "@material/material-color-utilities";
-import { setThemeProperties } from "./themes";
-
+import { downloadCss, setThemeProperties } from "./themes";
 
 globalThis.M = M  
+globalThis.downloadCss = downloadCss
 
 document.addEventListener("DOMContentLoaded", function() {
   function rgb2hex(rgb: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ document.addEventListener("DOMContentLoaded", function() {
       description: el.description,
       url: el.url,
     }));
-    M.Autocomplete.init(searchInput, {
+    M.Autocomplete.init(<HTMLInputElement> searchInput, {
       minLength: 1,
       data: pages,
       onAutocomplete: (items) => {
@@ -167,7 +167,7 @@ document.addEventListener("DOMContentLoaded", function() {
     const offsetTop = Math.floor(
       contentBox.top + window.scrollY - document.documentElement.clientTop
     );
-    M.Pushpin.init(navElem, {
+    M.Pushpin.init(<HTMLElement> navElem, {
       top: offsetTop,
       bottom: offsetTop + contentBox.height - navBox.height,
     });
@@ -192,7 +192,7 @@ document.addEventListener("DOMContentLoaded", function() {
       themeSwitch.classList.remove("is-dark");
       themeSwitch.querySelector("i").innerText = "dark_mode";
       (themeSwitch as any).title = "Switch to dark mode";
-    }
+    }   
     let themeColor = localStorage.getItem('theme-color');
     if (!themeColor)
       themeColor = "#006495"
@@ -1655,8 +1655,7 @@ document.addEventListener("DOMContentLoaded", function() {
   );
 
   M.Chips.init(document.querySelectorAll(".chips"), {});
-  M.Chips.init(document.querySelectorAll(".chips-initial"), {
-    readOnly: true,
+  M.Chips.init(document.querySelectorAll(".chips-initial"), {    
     data: autocompleteDemoData.filter((country) =>
       ["ma", "ta", "er", "ia", "li", "ze"].includes(country.id)
     ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,13 @@ import Prism from "prismjs";
 import "./style.scss";
 import "prismjs/themes/prism.min.css";
 import { config } from "../config.materialize";
-import { argbFromHex, themeFromSourceColor, applyTheme } from "@material/material-color-utilities";
-import { downloadCss, setThemeProperties } from "./themes";
+import { argbFromHex, themeFromSourceColor } from "@material/material-color-utilities";
+import { Themes } from "./themes";
 
 globalThis.M = M  
-globalThis.downloadCss = downloadCss
 
 document.addEventListener("DOMContentLoaded", function() {
+  const themes = new Themes(document)
   function rgb2hex(rgb: string) {
     if (/^#[0-9A-F]{6}$/i.test(rgb)) return rgb;
     const rgbMatch = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
@@ -179,73 +179,33 @@ document.addEventListener("DOMContentLoaded", function() {
       "auto";
   }
 
-  // Theme
-  const theme = localStorage.getItem("theme");
-  const themeColor = localStorage.getItem('theme-color');
-  const themeSwitch = document.querySelector("#theme-switch");
-  const setTheme = (isDark) => {
-    if (isDark) {
-      themeSwitch.classList.add("is-dark");
-      themeSwitch.querySelector("i").innerText = "light_mode";
-      (themeSwitch as any).title = "Switch to light mode";
-    } else {
-      themeSwitch.classList.remove("is-dark");
-      themeSwitch.querySelector("i").innerText = "dark_mode";
-      (themeSwitch as any).title = "Switch to dark mode";
-    }   
-    let themeColor = localStorage.getItem('theme-color');
-    if (!themeColor)
-      themeColor = "#006495"
-    const color = argbFromHex(themeColor)
-    
-    const atheme = themeFromSourceColor(color)
-    applyTheme(atheme, {target: document.body, dark: isDark, brightnessSuffix: true})
-    setThemeProperties(document.body)
-  };
-  const setThemeColor = (colorStr) => {
-    localStorage.setItem('theme-color', colorStr)
-    const color = argbFromHex(colorStr)
-    
-    const atheme = themeFromSourceColor(color)
-    
-    // Print out the theme as JSON
-    console.log(JSON.stringify(atheme, null, 2))
-    
-    // Check if the user has dark mode turned on
-    //const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches
-    const theme = localStorage.getItem("theme");    
-    
-    // Apply the theme to the body by updating custom properties for material tokens
-    //applyTheme(atheme, {target: document.body, dark: true, brightnessSuffix: true})
-    applyTheme(atheme, {target: document.body, dark: theme != null, brightnessSuffix: true})
-    setThemeProperties(document.body)
-  }
-  if (themeSwitch) {
-    // Load
-    if (theme) setTheme(true);
-    if (themeColor) setThemeColor(themeColor)
-    // Change
+  themes.applyThemeProperties();
+  const themeSwitch = document.querySelector("#theme-switch");  
+ 
+  if (themeSwitch) {    
     themeSwitch.addEventListener("click", (e) => {
       e.preventDefault();
       if (!themeSwitch.classList.contains("is-dark")) {
-        // Dark Theme
-        document.documentElement.setAttribute("theme", "dark");
-        localStorage.setItem("theme", "dark");
-        setTheme(true);
-      } else {
-        // Light Theme
-        document.documentElement.removeAttribute("theme");
-        localStorage.removeItem("theme");
-        setTheme(false);
+        // Dark Theme        
+        themeSwitch.classList.add("is-dark");
+        themeSwitch.querySelector("i").innerText = "light_mode";
+        (themeSwitch as any).title = "Switch to light mode";
+        themes.setDarkMode();
+      } else {        
+        themeSwitch.classList.remove("is-dark");
+        themeSwitch.querySelector("i").innerText = "dark_mode";
+        (themeSwitch as any).title = "Switch to dark mode";
+        themes.setLightMode()    
       }
     });
   }
   const toggleColorsButton = <HTMLInputElement> document.getElementById('color-picker');
-  if (toggleColorsButton && themeColor) {
-    toggleColorsButton.value = themeColor
+  const themePrimaryColor = themes.getThemePrimaryColor();
+  if (toggleColorsButton && themePrimaryColor) {
+    toggleColorsButton.value = themePrimaryColor
   }
   toggleColorsButton?.addEventListener('change', () => {
-    setThemeColor(toggleColorsButton.value)
+    themes.setThemePrimaryColor(toggleColorsButton.value)
   });
 
   // Copy Button

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,485 +1,491 @@
 @import "material-icons/iconfont/material-icons.css";
 @import "@materializecss/materialize/sass/materialize.scss";
-
 $border-color: $divider-color;
-$font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans,
-  Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+$font-stack: -apple-system,
+BlinkMacSystemFont,
+"Segoe UI",
+Roboto,
+Oxygen-Sans,
+Ubuntu,
+Cantarell,
+"Helvetica Neue",
+sans-serif;
 
 /***************
   HTML Styles
 ***************/
+
 body {
-  //background-color: #fcfcfc;
-  color: $text-color;
-  line-height: 1.6;
-  font-size: 16px;
-  -webkit-font-smoothing: antialiased;
-  background-color: var(--background-color);
+    //background-color: #fcfcfc;
+    color: $text-color;
+    line-height: 1.6;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+    background-color: var(--background-color);
 }
 
 p.box {
-  padding: 20px;
+    padding: 20px;
 }
 
 p {
-  padding: 0;
+    padding: 0;
 }
 
-h5 > span {
-  font-size: 14px;
-  margin-left: 15px;
-  color: $font-color-medium;
+h5>span {
+    font-size: 14px;
+    margin-left: 15px;
+    color: $font-color-medium;
 }
 
 td,
 th {
-  padding: 15px 10px;
+    padding: 15px 10px;
 }
 
 .header {
-  color: $font-color-main; //$primary-color;
-  font-weight: 400;
-  font-size: 3.25rem;
+    color: $font-color-main; //$primary-color;
+    font-weight: 400;
+    font-size: 3.25rem;
 }
 
 .preview {
-  background-color: $surface-color;
-  border: 1px solid $border-color;
-  padding: 20px 20px;
+    background-color: $surface-color;
+    border: 1px solid $border-color;
+    padding: 20px 20px;
 }
 
 .method-header {
-  font-family: "Inconsolata", Monaco, Consolas, "Andale Mono", monospace;
-  margin-top: 15px;
-  padding-top: 30px;
+    font-family: "Inconsolata", Monaco, Consolas, "Andale Mono", monospace;
+    margin-top: 15px;
+    padding-top: 30px;
 }
 
 header,
 main,
 footer {
-  padding-left: 300px;
+    padding-left: 300px;
 }
 
 .parallax-demo header,
 .parallax-demo main,
 .parallax-demo footer {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 footer.example {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 @media #{$medium-and-down} {
-  header,
-  main,
-  footer {
-    padding-left: 0;
-  }
-  h5 > span {
-    display: block;
-    margin: 0 0 15px 0;
-  }
+    header,
+    main,
+    footer {
+        padding-left: 0;
+    }
+    h5>span {
+        display: block;
+        margin: 0 0 15px 0;
+    }
 }
+
 
 /********************
   Index Page Styles
 ********************/
 
 #logo-container {
-  margin: 0;
-  padding: 1rem;
-  border-radius: unset;
-  height: 75px;
-  display: flex;
-  gap: 1rem;
-  font-size: 1.5rem;
+    margin: 0;
+    padding: 1rem;
+    border-radius: unset;
+    height: 75px;
+    display: flex;
+    gap: 1rem;
+    font-size: 1.5rem;
 }
 
 #front-page-logo {
-  display: inline-block;
-  height: 42px;
-  width: 90px;
-  object-fit: contain;
-  pointer-events: none;
-  margin: 1rem 0;
+    display: inline-block;
+    height: 42px;
+    width: 90px;
+    object-fit: contain;
+    pointer-events: none;
+    margin: 1rem 0;
 }
 
 .current-version-number {
-  font-size: 1.5rem;
-  font-weight: 500;
-  color: $font-color-medium;
+    font-size: 1.5rem;
+    font-weight: 500;
+    color: $font-color-medium;
 }
 
 .intro {
-  //background-color: color-mix(in srgb, var(--primary-color) 30%, var(--background-color));
-  padding: 6rem 0;
+    //background-color: color-mix(in srgb, var(--primary-color) 30%, var(--background-color));
+    padding: 6rem 0;
 }
+
 .intro #logo {
-  height: 150px;
+    height: 150px;
 }
+
 .intro h2 {
-  font-size: 2rem;
-  line-height: 1.25;
-  margin-bottom: 2rem;
+    font-size: 2rem;
+    line-height: 1.25;
+    margin-bottom: 2rem;
 }
 
 .slogan {
-  font-size: 1.75rem;
-  line-height: 1.25;
-  margin: 0;
-  margin-top: 1rem;
-  margin-bottom: 3rem;
+    font-size: 1.75rem;
+    line-height: 1.25;
+    margin: 0;
+    margin-top: 1rem;
+    margin-bottom: 3rem;
 }
 
 .materialize-benefits .card {
-  padding: 1.5rem;
+    padding: 1.5rem;
 }
+
 .materialize-benefits h2 {
-  font-size: 1.25rem;
-  font-weight: 500;
-  margin-top: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-top: 0;
 }
+
 .materialize-benefits p {
-  font-size: 1rem;
+    font-size: 1rem;
 }
 
 .sponsors h3 {
-  font-size: 1.75rem;
-  font-weight: 500;
+    font-size: 1.75rem;
+    font-weight: 500;
 }
 
 @media #{$medium-and-down} {
-  .intro {
-    padding: 3rem 0;
-  }
-  footer.page-footer .container {
-    text-align: center;
-  }
+    .intro {
+        padding: 3rem 0;
+    }
+    footer.page-footer .container {
+        text-align: center;
+    }
 }
 
 nav.top-nav {
-  height: 110px;
-  box-shadow: none;
-  border-bottom: 1px solid $border-color;
-  background-color: transparent;
-
-  h1.header {
-    margin: 0;
-    padding-top: 22px;
-  }
+    height: 110px;
+    box-shadow: none;
+    border-bottom: 1px solid $border-color;
+    background-color: transparent;
+    h1.header {
+        margin: 0;
+        padding-top: 22px;
+    }
 }
 
 a.sidenav-trigger.top-nav {
-  position: absolute;
-  text-align: center;
-  height: 48px;
-  width: 48px;
-  top: 28px;
-  //float: none;
-  margin-left: 1.5rem;
-  color: $primary-color;
-  font-size: 36px;
-  z-index: 2;
-
-  i {
-    font-size: 32px;
-  }
+    position: absolute;
+    text-align: center;
+    height: 48px;
+    width: 48px;
+    top: 28px;
+    //float: none;
+    margin-left: 1.5rem;
+    color: $primary-color;
+    font-size: 36px;
+    z-index: 2;
+    i {
+        font-size: 32px;
+    }
 }
 
 @media #{$small-and-down} {
-  a.sidenav-trigger.top-nav {
-    left: 0;
-  }
-  ul.sidenav.sidenav-fixed {
-    border: 0;
-  }
+    a.sidenav-trigger.top-nav {
+        left: 0;
+    }
+    ul.sidenav.sidenav-fixed {
+        border: 0;
+    }
 }
 
 @media #{$medium-and-down} {
-  nav .nav-wrapper {
-    text-align: center;
-    a.page-title {
-      font-size: 36px;
+    nav .nav-wrapper {
+        text-align: center;
+        a.page-title {
+            font-size: 36px;
+        }
     }
-  }
 }
 
 @media #{$medium-and-up} {
-  main > .container,
-  body > .page-footer > .container,
-  .top-nav > .container,
-  #index-banner > .container,
-  .github-commit > .container {
-    width: 100%;
-  }
+    main>.container,
+    body>.page-footer>.container,
+    .top-nav>.container,
+    #index-banner>.container,
+    .github-commit>.container {
+        width: 100%;
+    }
 }
 
 #responsive-img {
-  width: 80%;
-  display: block;
-  margin: 0 auto;
+    width: 80%;
+    display: block;
+    margin: 0 auto;
 }
 
 #index-banner {
-  border-bottom: 1px solid $border-color;
-  .container {
-    position: relative;
-  }
-  h4 {
-    margin-bottom: 40px;
-    line-height: 44px;
-    color: $font-color-main;
-  }
-  h1 {
-    margin-top: 16px;
-  }
+    border-bottom: 1px solid $border-color;
+    .container {
+        position: relative;
+    }
+    h4 {
+        margin-bottom: 40px;
+        line-height: 44px;
+        color: $font-color-main;
+    }
+    h1 {
+        margin-top: 16px;
+    }
 }
 
 @media #{$medium-and-down} {
-  #index-banner {
-    h1 {
-      margin-top: 1rem;
+    #index-banner {
+        h1 {
+            margin-top: 1rem;
+        }
+        h4 {
+            margin-bottom: 15px;
+        }
     }
-    h4 {
-      margin-bottom: 15px;
-    }
-  }
 }
 
 @media #{$small-and-down} {
-  #index-banner {
-    h4 {
-      margin-bottom: 0;
+    #index-banner {
+        h4 {
+            margin-bottom: 0;
+        }
     }
-  }
 }
 
 // Latest commit widget
 .github-commit {
-  color: $font-color-medium;
-  border-top: 1px solid $border-color;
-  padding: 14px 0;
-  height: 64px;
-  line-height: 36px;
-  font-size: 0.9rem;
-
-  .sha {
-    margin: 0 6px 0 6px;
-  }
+    color: $font-color-medium;
+    border-top: 1px solid $border-color;
+    padding: 14px 0;
+    height: 64px;
+    line-height: 36px;
+    font-size: 0.9rem;
+    .sha {
+        margin: 0 6px 0 6px;
+    }
 }
 
 @media #{$medium-and-down} {
-  .github-commit {
-    text-align: center;
-  }
+    .github-commit {
+        text-align: center;
+    }
 }
 
 .promo {
-  width: 100%;
-  i {
-    margin: 30px 0;
-    //color: $primary-color;
-    color: $secondary-color;
-    font-size: 5rem;
-    display: block;
-  }
+    width: 100%;
+    i {
+        margin: 30px 0;
+        //color: $primary-color;
+        color: $secondary-color;
+        font-size: 5rem;
+        display: block;
+    }
 }
 
 .promo-caption {
-  font-size: 1.25rem;
-  font-weight: 500;
-  margin-top: 5px;
-  margin-bottom: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-top: 5px;
+    margin-bottom: 0;
 }
 
 // Grid doc styles
-
 .grid-example {
-  border: 1px solid $border-color;
-  text-align: center;
-  font-size: 26px;
-  background-color: lightcoral;
-  color: white;
-  //margin: 7px 0;
-  // line-height: 50px;
-  // font-weight: bold;
-  // padding: 0;
-
-  span {
-    //font-weight: 100;
-    line-height: 50px;
-  }
+    border: 1px solid $border-color;
+    text-align: center;
+    font-size: 26px;
+    background-color: lightcoral;
+    color: white;
+    //margin: 7px 0;
+    // line-height: 50px;
+    // font-weight: bold;
+    // padding: 0;
+    span {
+        //font-weight: 100;
+        line-height: 50px;
+    }
 }
 
 .promo-example {
-  overflow: hidden;
+    overflow: hidden;
 }
+
 
 /*******************
   Flat Site Mockup
 *******************/
 
 #site-layout-example-left {
-  background-color: color("blue-grey", "lighten-2");
-  height: 300px;
+    background-color: color("blue-grey", "lighten-2");
+    height: 300px;
 }
 
 #site-layout-example-right {
-  background-color: $secondary-color;
-  height: 300px;
+    background-color: $secondary-color;
+    height: 300px;
 }
 
 #site-layout-example-top {
-  background-color: $primary-color;
-  height: 42px;
+    background-color: $primary-color;
+    height: 42px;
 }
 
 .flat-text-header {
-  height: 35px;
-  width: 80%;
-  background-color: rgba(255, 255, 255, 0.15);
-  display: block;
-  margin: 27px auto;
+    height: 35px;
+    width: 80%;
+    background-color: rgba(255, 255, 255, 0.15);
+    display: block;
+    margin: 27px auto;
 }
 
 .flat-text {
-  height: 25px;
-  width: 80%;
-  background-color: rgba(0, 0, 0, 0.15);
-  display: block;
-  margin: 27px auto;
-
-  &.small {
-    width: 25%;
     height: 25px;
+    width: 80%;
     background-color: rgba(0, 0, 0, 0.15);
-  }
-
-  &.full-width {
-    width: 100%;
-  }
+    display: block;
+    margin: 27px auto;
+    &.small {
+        width: 25%;
+        height: 25px;
+        background-color: rgba(0, 0, 0, 0.15);
+    }
+    &.full-width {
+        width: 100%;
+    }
 }
+
 
 /**********************
 **********************/
 
+
 /*****************
   Chrome Browser
 *****************/
+
 $bottomColor: #e2e2e1;
 $topColor: lighten($bottomColor, 2%);
-
 $width: 100%;
 $height: auto;
-
 .browser-window {
-  text-align: left;
-  width: $width;
-  height: $height;
-  display: inline-block;
-  border-radius: 5px 5px 2px 2px;
-  background-color: var(--background-color-level-4dp);
-  margin: 20px 0px;
-  overflow: hidden;
-
-  .top-bar {
-    height: 30px;
-    border-radius: 5px 5px 0 0;
-    border-top: thin solid lighten($topColor, 1%);
-    border-bottom: thin solid darken($bottomColor, 1%);
-    background: linear-gradient($topColor, $bottomColor);
-  }
+    text-align: left;
+    width: $width;
+    height: $height;
+    display: inline-block;
+    border-radius: 5px 5px 2px 2px;
+    background-color: var(--background-color-level-4dp);
+    margin: 20px 0px;
+    overflow: hidden;
+    .top-bar {
+        height: 30px;
+        border-radius: 5px 5px 0 0;
+        border-top: thin solid lighten($topColor, 1%);
+        border-bottom: thin solid darken($bottomColor, 1%);
+        background: linear-gradient($topColor, $bottomColor);
+    }
 }
 
 .browser-window .circle {
-  height: 10px;
-  width: 10px;
-  display: inline-block;
-  border-radius: 50%;
-  background-color: lighten($topColor, 10%);
-  margin-right: 1px;
+    height: 10px;
+    width: 10px;
+    display: inline-block;
+    border-radius: 50%;
+    background-color: lighten($topColor, 10%);
+    margin-right: 1px;
 }
 
 #close-circle {
-  background-color: #ff5c5a;
+    background-color: #ff5c5a;
 }
 
 #minimize-circle {
-  background-color: #ffbb50;
+    background-color: #ffbb50;
 }
 
 #maximize-circle {
-  background-color: #1bc656;
+    background-color: #1bc656;
 }
 
 .browser-window .circles {
-  margin: 5px 12px;
+    margin: 5px 12px;
 }
 
 .browser-window .content {
-  margin: 0;
-  width: 100%;
-  // min-height: 100%;
-  display: inline-block;
-  border-radius: 0 0 5px 5px;
-  background-color: #fafafa;
+    margin: 0;
+    width: 100%;
+    // min-height: 100%;
+    display: inline-block;
+    border-radius: 0 0 5px 5px;
+    background-color: #fafafa;
 }
 
 .browser-window .row {
-  margin: 0;
+    margin: 0;
 }
 
 .clear {
-  clear: both;
+    clear: both;
 }
+
 
 /**********************
 **********************/
 
 // Color Wheel
 .dynamic-color {
-  .red,
-  .pink,
-  .purple,
-  .deep-purple,
-  .indigo,
-  .blue,
-  .light-blue,
-  .cyan,
-  .teal,
-  .green,
-  .light-green,
-  .lime,
-  .yellow,
-  .amber,
-  .orange,
-  .deep-orange,
-  .brown,
-  .grey,
-  .blue-grey,
-  .black,
-  .white,
-  .transparent {
-    height: 55px;
-    width: 100%;
-    padding: 0 15px;
-    font-weight: 500;
-    font-size: 12px;
-    display: flex;
-    justify-content: center;
-    flex-direction: column;
-    box-sizing: border-box;
-  }
-
-  .col {
-    margin-bottom: 55px;
-  }
+    .red,
+    .pink,
+    .purple,
+    .deep-purple,
+    .indigo,
+    .blue,
+    .light-blue,
+    .cyan,
+    .teal,
+    .green,
+    .light-green,
+    .lime,
+    .yellow,
+    .amber,
+    .orange,
+    .deep-orange,
+    .brown,
+    .grey,
+    .blue-grey,
+    .black,
+    .white,
+    .transparent {
+        height: 55px;
+        width: 100%;
+        padding: 0 15px;
+        font-weight: 500;
+        font-size: 12px;
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
+        box-sizing: border-box;
+    }
+    .col {
+        margin-bottom: 55px;
+    }
 }
 
 .center {
-  text-align: center;
-  vertical-align: middle;
+    text-align: center;
+    vertical-align: middle;
 }
 
 // Icons
@@ -487,395 +493,407 @@ $height: auto;
 .material-symbols-outlined.icon-demo,
 .material-symbols-rounded.icon-demo,
 .material-symbols-sharp.icon-demo {
-  line-height: 50px;
+    line-height: 50px;
 }
+
 .icon-container i {
-  font-size: 3em;
-  margin-bottom: 10px;
+    font-size: 3em;
+    margin-bottom: 10px;
 }
+
 .icon-container .icon-preview {
-  height: 120px;
-  text-align: center;
+    height: 120px;
+    text-align: center;
 }
+
 .icon-container span {
-  display: block;
+    display: block;
 }
+
 .icon-holder {
-  display: block;
-  text-align: center;
-  width: 150px;
-  height: 115px;
-  float: left;
-  margin: 0 0px 15px 0px;
-  p {
-    margin: 0 0;
-  }
+    display: block;
+    text-align: center;
+    width: 150px;
+    height: 115px;
+    float: left;
+    margin: 0 0px 15px 0px;
+    p {
+        margin: 0 0;
+    }
 }
 
 // tabs
 .tabs-wrapper {
-  position: relative;
-  height: 48px;
-  @extend .hide-on-small-only;
-
-  .row.pinned {
-    position: fixed;
-    width: 100%;
-    top: 0;
-    z-index: 10;
-  }
+    position: relative;
+    height: 48px;
+    @extend .hide-on-small-only;
+    .row.pinned {
+        position: fixed;
+        width: 100%;
+        top: 0;
+        z-index: 10;
+    }
 }
 
 // Shadow demo styling
 .shadow-demo {
-  background-color: $secondary-color;
-  width: 100px;
-  height: 100px;
-  margin: 20px auto;
-  @media only screen and (max-width: $small-screen) {
-    width: 150px;
-    height: 150px;
-  }
+    background-color: $secondary-color;
+    width: 100px;
+    height: 100px;
+    margin: 20px auto;
+    @media only screen and (max-width: $small-screen) {
+        width: 150px;
+        height: 150px;
+    }
 }
 
 // parallax demo
 .parallax-container {
-  .text-center {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    margin-top: -27px;
-  }
+    .text-center {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        margin-top: -27px;
+    }
 }
 
 // Table of contents
 ul.table-of-contents {
-  padding-left: 0;
-  list-style-type: none;
-  margin-top: 0;
-  padding-top: 48px;
-  font-size: 1rem;
-  margin-left: 4rem;
+    padding-left: 0;
+    list-style-type: none;
+    margin-top: 0;
+    padding-top: 48px;
+    font-size: 1rem;
+    margin-left: 4rem;
 }
 
 // Prism Styling
 code,
 pre {
-  position: relative;
-  font-size: 1.1rem;
+    position: relative;
+    font-size: 1.1rem;
 }
 
 .directory-markup {
-  font-size: 1rem;
-  line-height: 1.1rem !important;
+    font-size: 1rem;
+    line-height: 1.1rem !important;
 }
 
-:not(pre) > code[class*="language-"] {
-  padding: 0.1em 0.25em;
-  border: solid 1px $divider-color;
+:not(pre)>code[class*="language-"] {
+    padding: 0.1em 0.25em;
+    border: solid 1px $divider-color;
 }
 
 // Styles code blocks
 pre[class*="language-"] {
-  &:before {
-    position: absolute;
-    padding: 1px 5px;
-    background: var(--background-color-level-16dp-solid);
-    top: 0;
-    left: 0;
-    font-family: $font-stack;
-    -webkit-font-smoothing: antialiased;
-    color: $font-color-medium;
-    content: attr(class);
-    font-size: 0.9rem;
+    &:before {
+        position: absolute;
+        padding: 1px 5px;
+        background: var(--background-color-level-16dp-solid);
+        top: 0;
+        left: 0;
+        font-family: $font-stack;
+        -webkit-font-smoothing: antialiased;
+        color: $font-color-medium;
+        content: attr(class);
+        font-size: 0.9rem;
+        border: solid 1px $divider-color;
+        border-top: none;
+        border-left: none;
+    }
+    padding: 25px 12px 7px 12px;
     border: solid 1px $divider-color;
-    border-top: none;
-    border-left: none;
-  }
-
-  padding: 25px 12px 7px 12px;
-  border: solid 1px $divider-color;
-  background: var(--background-color-slight-emphasis);
+    background: var(--background-color-slight-emphasis);
 }
 
 .token.operator {
-  background: transparent;
+    background: transparent;
 }
 
 pre[class*="language-"],
 code[class*="language-"] {
-  line-height: 1.3;
+    line-height: 1.3;
 }
 
 code[class*="language-"] {
-  color: $font-color-main;
+    color: $font-color-main;
 }
 
 // Styles one-liners
-:not(pre) > code[class*="language-"] {
-  background: var(--background-color-slight-emphasis);
-  color: $font-color-main;
+:not(pre)>code[class*="language-"] {
+    background: var(--background-color-slight-emphasis);
+    color: $font-color-main;
 }
 
 // copy code icons
 .copyMessage,
 .copyButton {
-  color: $font-color-medium;
-  position: absolute;
+    color: $font-color-medium;
+    position: absolute;
 }
 
 .copyMessage {
-  font-size: 14px;
-  transition: all 0.2s ease-in;
-  opacity: 0;
-  right: 45px;
-  top: 15px;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 14px;
+    transition: all 0.2s ease-in;
+    opacity: 0;
+    right: 45px;
+    top: 15px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 .copyButton {
-  top: 10px;
-  right: 10px;
-  cursor: pointer;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
 }
+
 
 /**********************************/
 
 @keyframes rotate {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
 }
 
 .gradient {
-  --size: 100vh;
-  --speed: 25s;
-  --easing: cubic-bezier(0.8, 0.2, 0.2, 0.8);
-
-  width: var(--size);
-  height: var(--size);
-  filter: blur(calc(var(--size) / 5));
-  background-image: linear-gradient(
-    hsla(158, 81%, 41%, 0.85),
-    hsl(252, 59%, 63%)
-  );
-  animation: rotate var(--speed) var(--easing) alternate infinite;
-  border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;
+    --size: 100vh;
+    --speed: 25s;
+    --easing: cubic-bezier(0.8, 0.2, 0.2, 0.8);
+    width: var(--size);
+    height: var(--size);
+    filter: blur(calc(var(--size) / 5));
+    background-image: linear-gradient( hsla(158, 81%, 41%, 0.85), hsl(252, 59%, 63%));
+    animation: rotate var(--speed) var(--easing) alternate infinite;
+    border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;
 }
+
 
 /***************************************/
 
 .toc-wrapper {
-  &.pin-bottom {
-    margin-top: 84px;
-  }
-  position: relative;
-  margin-top: 42px;
+    &.pin-bottom {
+        margin-top: 84px;
+    }
+    position: relative;
+    margin-top: 42px;
 }
 
 // Footer styling
 footer {
-  font-size: 0.9rem;
+    font-size: 0.9rem;
 }
 
 body.parallax-demo footer {
-  margin-top: 0;
+    margin-top: 0;
 }
 
 .docs-footer {
-  margin-top: 40px;
-  background-color: transparent;
-  border-top: 1px solid $border-color;
-  color: inherit;
-  .footer-copyright,
-  .footer-copyright a {
-    color: $font-color-medium;
+    margin-top: 40px;
     background-color: transparent;
-  }
+    border-top: 1px solid $border-color;
+    color: inherit;
+    .footer-copyright,
+    .footer-copyright a {
+        color: $font-color-medium;
+        background-color: transparent;
+    }
 }
 
 //About page styling
 .image-container {
-  width: 100%;
-  img {
-    max-width: 100%;
-  }
+    width: 100%;
+    img {
+        max-width: 100%;
+    }
 }
 
 // Mobile page styling
-
 .mobile-image {
-  @media #{$small-and-down} {
-    max-width: 100%;
-  }
+    @media #{$small-and-down} {
+        max-width: 100%;
+    }
 }
 
 // Waves page styling
 .waves-color-demo {
-  .collection-item {
-    height: 37px;
-    line-height: 37px;
-    box-sizing: content-box;
-
-    code {
-      line-height: 37px;
+    .collection-item {
+        height: 37px;
+        line-height: 37px;
+        box-sizing: content-box;
+        code {
+            line-height: 37px;
+        }
     }
-  }
-
-  .btn {
-    &:not(.waves-light) {
-      background-color: color("shades", "white");
-      color: #212121;
+    .btn {
+        &:not(.waves-light) {
+            background-color: color("shades", "white");
+            color: #212121;
+        }
     }
-  }
 }
 
 // Card Page styling
 .card-panel span,
 .card-content p {
-  -webkit-font-smoothing: antialiased;
+    -webkit-font-smoothing: antialiased;
 }
 
 #images .card-panel .row {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 // Pushpin Demo styles
 .pushpin-demo {
-  position: relative;
-  height: 100px;
+    position: relative;
+    height: 100px;
 }
+
 #pushpin-demo-1 {
-  display: block;
-  height: inherit;
-  background-color: var(--slider-track-color);
+    display: block;
+    height: inherit;
+    background-color: var(--slider-track-color);
 }
 
 // Valign Demo
 .valign-demo {
-  height: 400px;
-  border: 1px solid var(--secondary-color);
+    height: 400px;
+    border: 1px solid var(--secondary-color);
 }
+
 .talign-demo {
-  height: 100px;
-  border: 1px solid var(--secondary-color);
+    height: 100px;
+    border: 1px solid var(--secondary-color);
 }
 
 // Transitions demos
 #staggered-test li,
 #image-test {
-  opacity: 0;
+    opacity: 0;
 }
 
 // Thanks for Downloading
 #download-thanks {
-  transition: all 0.3s ease-in-out;
-  overflow: hidden;
-  max-height: 300px;
-  opacity: 1;
-  margin: 1rem 0;
-  padding: 1rem;
+    transition: all 0.3s ease-in-out;
+    overflow: hidden;
+    max-height: 300px;
+    opacity: 1;
+    margin: 1rem 0;
+    padding: 1rem;
 }
+
 #download-thanks .header {
-  font-size: 1.75em;
-  color: $primary-color;
-  margin: 0;
+    font-size: 1.75em;
+    color: $primary-color;
+    margin: 0;
 }
+
 #download-thanks.is-closed {
-  opacity: 0;
-  max-height: 0;
+    opacity: 0;
+    max-height: 0;
 }
 
 // For GitHub and OpenCollective
-.ext-link > img {
-  vertical-align: middle;
-  height: 24px;
+.ext-link>img {
+    vertical-align: middle;
+    height: 24px;
 }
 
 // Search
 #nav-mobile li.search {
-  margin: 5px 0;
-  z-index: 2;
-
-  .search-wrapper {
-    color: $font-color-medium;
-    margin-top: -1px;
-    transition: margin 0.25s ease;
-    position: relative;
-
-    input#search {
-      &:focus {
-        outline: none;
-        box-shadow: none;
-      }
-      background-color: transparent;
-      border: 1px solid $border-color;
-      border-radius: 3px;
-      margin: 0 auto;
-      color: $font-color-medium;
-      display: block;
-      font-size: 16px;
-      width: 80%;
-      padding: 5px;
-      box-sizing: border-box;
-      height: 32px;
+    margin: 5px 0;
+    z-index: 2;
+    .search-wrapper {
+        color: $font-color-medium;
+        margin-top: -1px;
+        transition: margin 0.25s ease;
+        position: relative;
+        input#search {
+            &:focus {
+                outline: none;
+                box-shadow: none;
+            }
+            background-color: transparent;
+            border: 1px solid $border-color;
+            border-radius: 3px;
+            margin: 0 auto;
+            color: $font-color-medium;
+            display: block;
+            font-size: 16px;
+            width: 80%;
+            padding: 5px;
+            box-sizing: border-box;
+            height: 32px;
+        }
+        i.material-icons,
+        i.material-symbols-outlined,
+        i.material-symbols-rounded,
+        i.material-symbols-sharp {
+            position: absolute;
+            top: 4px;
+            right: 34px;
+            color: $border-color;
+            cursor: pointer;
+        }
     }
-
-    i.material-icons,
-    i.material-symbols-outlined,
-    i.material-symbols-rounded,
-    i.material-symbols-sharp {
-      position: absolute;
-      top: 4px;
-      right: 34px;
-      color: $border-color;
-      cursor: pointer;
-    }
-  }
 }
 
 .search-results {
-  position: fixed;
-  margin: 0;
-
-  top: 65px;
-  left: 340px;
-
-  @media #{$medium-and-down} {
+    position: fixed;
+    margin: 0;
     top: 65px;
-    left: 100px;
-  }
-  @media #{$small-and-down} {
-    top: 160px;
-    left: 35px;
-  }
-
-  z-index: 9999;
-  background-color: $surface-color;
-  a {
-    font-size: 12px;
-    padding: 5px;
-    &.focused {
-      background-color: $surface-focus-color-opaque;
-      outline: none;
+    left: 340px;
+    @media #{$medium-and-down} {
+        top: 65px;
+        left: 100px;
     }
-    &:hover {
-      background-color: $surface-hover-color-opaque;
-      outline: none;
+    @media #{$small-and-down} {
+        top: 160px;
+        left: 35px;
     }
-    white-space: nowrap;
-    display: block;
-  }
+    z-index: 9999;
+    background-color: $surface-color;
+    a {
+        font-size: 12px;
+        padding: 5px;
+        &.focused {
+            background-color: $surface-focus-color-opaque;
+            outline: none;
+        }
+        &:hover {
+            background-color: $surface-hover-color-opaque;
+            outline: none;
+        }
+        white-space: nowrap;
+        display: block;
+    }
 }
 
 #nav-mobile {
-  li .new.badge {
-    background-color: var(--secondary-color);
-    color: var(--font-on-secondary-color-main);
-  }
+    li .new.badge {
+        background-color: var(--secondary-color);
+        color: var(--font-on-secondary-color-main);
+    }
+}
+
+#palette-selector {
+    width: 420px;
+    .modal-content {
+        display: grid;
+        grid-auto-rows: 80px 60px 40px;
+        align-items: start;
+    }
+    .color-row {
+        display: grid;
+        grid-template-columns: 120px 60px;
+        justify-items: left;
+        align-items: center;
+        label {
+            margin-left: 20px;
+        }
+    }
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,3 +1,6 @@
+import { argbFromHex, themeFromSourceColor } from "@material/material-color-utilities";
+import { CssGenerator } from "./css-generator";
+
 function setThemeProperty(target: HTMLElement, targetProp:string, sourceProp: string)
 {
   const color = target.style.getPropertyValue(sourceProp);
@@ -66,3 +69,32 @@ export function setThemeProperties(target: HTMLElement)
   
     // --md_sys_color_on-surface: 28, 27, 31;
   }
+
+  
+export function downloadCss()
+{
+  let themeColor = localStorage.getItem('theme-color');
+  if (!themeColor)
+    themeColor = "#006495"
+  const color = argbFromHex(themeColor)
+    
+  const generator = new CssGenerator(themeFromSourceColor(color))
+  var fileLines = generator.tokens();  
+  downloadFile('tokens.module.scss', fileLines.join('\n'));
+
+}
+
+
+function downloadFile(filename, text) {
+  var element = document.createElement('a');
+  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  element.setAttribute('download', filename);
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+}
+

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,100 +1,140 @@
-import { argbFromHex, themeFromSourceColor } from "@material/material-color-utilities";
+import { applyTheme, argbFromHex, themeFromSourceColor } from "@material/material-color-utilities";
 import { CssGenerator } from "./css-generator";
 
-function setThemeProperty(target: HTMLElement, targetProp:string, sourceProp: string)
-{
-  const color = target.style.getPropertyValue(sourceProp);
-  target.style.setProperty(targetProp, color);
-}
+export class Themes {
+  static themePrimaryColorStorageKey: string = 'theme-primary-color';
+  static themeModeStorageKey: string = 'theme-mode';
 
-export function setThemeProperties(target: HTMLElement)
+  constructor(private document: Document)
   {
-    setThemeProperty(target, '--surface-color', '--md-sys-color-surface')
-    setThemeProperty(target, '--background-color', '--md-sys-color-background')
-    setThemeProperty(target, '--font-color-main', '--md-sys-color-on-background')
-    setThemeProperty(target, '--font-color-medium', '--md-sys-color-on-surface-variant')
-    setThemeProperty(target, '--font-color-disabled', '--md-sys-color-on-surface')
-    setThemeProperty(target, '--font-on-primary-color-main', '--md-sys-color-on-primary')
-    setThemeProperty(target, '--font-on-primary-color-dark-main', '--md-sys-color-on-primary-dark')
-    setThemeProperty(target, '--font-on-primary-color-dark-medium', '--md-sys-color-on-surface-variant-dark')
-    setThemeProperty(target, '--font-on-primary-color-medium', '--md-sys-color-on-surface-variant')
-    //setThemeProperty(target, '---font-on-primary-color-disabled', '--')
-    setThemeProperty(target, '--font-on-secondary-color-main', '--md-sys-color-on-secondary')
+
+  } 
+  
+  setThemePrimaryColor(value: string) {    
+    localStorage.setItem(Themes.themePrimaryColorStorageKey, value);
+    this.applyThemeProperties();
+  }
+
+  getThemePrimaryColor(): string {
+    let themeColor = localStorage.getItem(Themes.themePrimaryColorStorageKey);
+    if (!themeColor)
+      themeColor = "#006495"
+    return themeColor;
+  }
+
+  setLightMode() {
+    this.document.documentElement.setAttribute("theme", "light");
+    localStorage.setItem(Themes.themeModeStorageKey, "light");
+    this.applyThemeProperties()    
+  }
+  setDarkMode() {
+    this.document.documentElement.setAttribute("theme", "dark");
+    localStorage.setItem("theme-mode", "dark");
+    this.applyThemeProperties()    
+  }
+
+  public applyThemeProperties() {
+    const mode = localStorage.getItem(Themes.themeModeStorageKey);    
+    const isDark = mode == "dark"
+
+    let themeColor = this.getThemePrimaryColor();
+    const color = argbFromHex(themeColor)
     
-    
-    
- 
+    const atheme = themeFromSourceColor(color)
+    const target = this.document.body;
+    applyTheme(atheme, {target: target, dark: isDark, brightnessSuffix: true})
+    this.setThemeProperties(target)
+  }
+
+  downloadCss() {    
+    const color = argbFromHex(this.getThemePrimaryColor())
+
+    const generator = new CssGenerator(themeFromSourceColor(color))
+    var fileLines = generator.tokens();
+    this.downloadFile('tokens.module.scss', fileLines.join('\n'));
+
+  }
+
+  downloadFile(filename, text) {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
+
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+
+    document.body.removeChild(element);
+  }
+
+  public setThemeProperties(target: HTMLElement) {
+    this.setThemeProperty(target, '--surface-color', '--md-sys-color-surface')
+    this.setThemeProperty(target, '--background-color', '--md-sys-color-background')
+    this.setThemeProperty(target, '--font-color-main', '--md-sys-color-on-background')
+    this.setThemeProperty(target, '--font-color-medium', '--md-sys-color-on-surface-variant')
+    this.setThemeProperty(target, '--font-color-disabled', '--md-sys-color-on-surface')
+    this.setThemeProperty(target, '--font-on-primary-color-main', '--md-sys-color-on-primary')
+    this.setThemeProperty(target, '--font-on-primary-color-dark-main', '--md-sys-color-on-primary-dark')
+    this.setThemeProperty(target, '--font-on-primary-color-dark-medium', '--md-sys-color-on-surface-variant-dark')
+    this.setThemeProperty(target, '--font-on-primary-color-medium', '--md-sys-color-on-surface-variant')
+    //this.setThemeProperty(target, '---font-on-primary-color-disabled', '--')
+    this.setThemeProperty(target, '--font-on-secondary-color-main', '--md-sys-color-on-secondary')
+
+
+
+
     // --hover-color: rgba(0, 0, 0, 0.04);
     // --focus-color: rgba(0, 0, 0, 0.12);
     // --focus-color-solid: #E0E0E0;
-  
+
     // --background-color-disabled: rgba(0, 0, 0, 0.12);
     // --background-color-level-4dp: rgba(0, 0, 0, 0.09);
-    setThemeProperty(target, '--background-color-level-16dp-solid', '--surface-color')
-    
+    this.setThemeProperty(target, '--background-color-level-16dp-solid', '--surface-color')
+
     // --background-color-slight-emphasis: rgba(0, 0, 0, 0.08);
-    
-    setThemeProperty(target, '--background-color-card', '--surface-color')
-  
+
+    this.setThemeProperty(target, '--background-color-card', '--surface-color')
+
     // --tooltip-background-color: #313033;
     // --tooltip-font-color: rgba(255, 255, 255, 0.77);
-  
+
     // --separator-color: #DDDDDD; /* borders between components */
-  
+
     // --error-color: #F44336;
-  
-        
-    setThemeProperty(target, '--slider-track-color', '--md-sys-color-shadow-light')
-    setThemeProperty(target, '--switch-thumb-off-color', '--md-ref-palette-primary100')
-  
+
+
+    this.setThemeProperty(target, '--slider-track-color', '--md-sys-color-shadow-light')
+    this.setThemeProperty(target, '--switch-thumb-off-color', '--md-ref-palette-primary100')
+
     // --carousel-indicator-color: rgba(255, 255, 255, 0.45);
-    
-    setThemeProperty(target, '--carousel-indicator-active-color', '--md-ref-palette-primary100')    
-    setThemeProperty(target, '--primary-color', '--md-sys-color-primary')
-        
-  
-    setThemeProperty(target, '--primary-color-dark', '--md-sys-color-primary-dark')
-    setThemeProperty(target, '--primary-color-raised-hover-solid', '--md-ref-palette-primary80')
+
+    this.setThemeProperty(target, '--carousel-indicator-active-color', '--md-ref-palette-primary100')
+    this.setThemeProperty(target, '--primary-color', '--md-sys-color-primary')
+
+
+    this.setThemeProperty(target, '--primary-color-dark', '--md-sys-color-primary-dark')
+    this.setThemeProperty(target, '--primary-color-raised-hover-solid', '--md-ref-palette-primary80')
     // --primary-color-font-medium-color: rgba(var(--primary-color-numeric), 0.7);
     // --primary-color-font-disabled-color: rgba(var(--primary-color-numeric), 0.4);
     // --primary-color-hover-opaque: rgba(var(--primary-color-numeric), 0.06);
     // --primary-color-focus-opaque: rgba(var(--primary-color-numeric), 0.18);
-    
-    setThemeProperty(target, '--secondary-color', '--md-sys-color-secondary')
-    setThemeProperty(target, '--secondary-color-hover-solid', '--md-ref-palette-secondary70')
-    setThemeProperty(target, '--secondary-color-focus-solid', '--md-ref-palette-secondary80')
-    setThemeProperty(target, '--secondary-container-color', '--md-sys-color-secondary-container')
-    setThemeProperty(target, '--font-on-secondary-container-color', '--md-sys-color-on-secondary-container')
 
-  
+    this.setThemeProperty(target, '--secondary-color', '--md-sys-color-secondary')
+    this.setThemeProperty(target, '--secondary-color-hover-solid', '--md-ref-palette-secondary70')
+    this.setThemeProperty(target, '--secondary-color-focus-solid', '--md-ref-palette-secondary80')
+    this.setThemeProperty(target, '--secondary-container-color', '--md-sys-color-secondary-container')
+    this.setThemeProperty(target, '--font-on-secondary-container-color', '--md-sys-color-on-secondary-container')
+
+
     // --md_sys_color_on-surface: 28, 27, 31;
   }
 
-  
-export function downloadCss()
-{
-  let themeColor = localStorage.getItem('theme-color');
-  if (!themeColor)
-    themeColor = "#006495"
-  const color = argbFromHex(themeColor)
-    
-  const generator = new CssGenerator(themeFromSourceColor(color))
-  var fileLines = generator.tokens();  
-  downloadFile('tokens.module.scss', fileLines.join('\n'));
+
+  setThemeProperty(target: HTMLElement, targetProp: string, sourceProp: string) {
+    const color = target.style.getPropertyValue(sourceProp);
+    target.style.setProperty(targetProp, color);
+  }
+
 
 }
-
-
-function downloadFile(filename, text) {
-  var element = document.createElement('a');
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-  element.setAttribute('download', filename);
-
-  element.style.display = 'none';
-  document.body.appendChild(element);
-
-  element.click();
-
-  document.body.removeChild(element);
-}
-

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,0 +1,68 @@
+function setThemeProperty(target: HTMLElement, targetProp:string, sourceProp: string)
+{
+  const color = target.style.getPropertyValue(sourceProp);
+  target.style.setProperty(targetProp, color);
+}
+
+export function setThemeProperties(target: HTMLElement)
+  {
+    setThemeProperty(target, '--surface-color', '--md-sys-color-surface')
+    setThemeProperty(target, '--background-color', '--md-sys-color-background')
+    setThemeProperty(target, '--font-color-main', '--md-sys-color-on-background')
+    setThemeProperty(target, '--font-color-medium', '--md-sys-color-on-surface-variant')
+    setThemeProperty(target, '--font-color-disabled', '--md-sys-color-on-surface')
+    setThemeProperty(target, '--font-on-primary-color-main', '--md-sys-color-on-primary')
+    setThemeProperty(target, '--font-on-primary-color-dark-main', '--md-sys-color-on-primary-dark')
+    setThemeProperty(target, '--font-on-primary-color-dark-medium', '--md-sys-color-on-surface-variant-dark')
+    setThemeProperty(target, '--font-on-primary-color-medium', '--md-sys-color-on-surface-variant')
+    //setThemeProperty(target, '---font-on-primary-color-disabled', '--')
+    setThemeProperty(target, '--font-on-secondary-color-main', '--md-sys-color-on-secondary')
+    
+    
+    
+ 
+    // --hover-color: rgba(0, 0, 0, 0.04);
+    // --focus-color: rgba(0, 0, 0, 0.12);
+    // --focus-color-solid: #E0E0E0;
+  
+    // --background-color-disabled: rgba(0, 0, 0, 0.12);
+    // --background-color-level-4dp: rgba(0, 0, 0, 0.09);
+    setThemeProperty(target, '--background-color-level-16dp-solid', '--surface-color')
+    
+    // --background-color-slight-emphasis: rgba(0, 0, 0, 0.08);
+    
+    setThemeProperty(target, '--background-color-card', '--surface-color')
+  
+    // --tooltip-background-color: #313033;
+    // --tooltip-font-color: rgba(255, 255, 255, 0.77);
+  
+    // --separator-color: #DDDDDD; /* borders between components */
+  
+    // --error-color: #F44336;
+  
+        
+    setThemeProperty(target, '--slider-track-color', '--md-sys-color-shadow-light')
+    setThemeProperty(target, '--switch-thumb-off-color', '--md-ref-palette-primary100')
+  
+    // --carousel-indicator-color: rgba(255, 255, 255, 0.45);
+    
+    setThemeProperty(target, '--carousel-indicator-active-color', '--md-ref-palette-primary100')    
+    setThemeProperty(target, '--primary-color', '--md-sys-color-primary')
+        
+  
+    setThemeProperty(target, '--primary-color-dark', '--md-sys-color-primary-dark')
+    setThemeProperty(target, '--primary-color-raised-hover-solid', '--md-ref-palette-primary80')
+    // --primary-color-font-medium-color: rgba(var(--primary-color-numeric), 0.7);
+    // --primary-color-font-disabled-color: rgba(var(--primary-color-numeric), 0.4);
+    // --primary-color-hover-opaque: rgba(var(--primary-color-numeric), 0.06);
+    // --primary-color-focus-opaque: rgba(var(--primary-color-numeric), 0.18);
+    
+    setThemeProperty(target, '--secondary-color', '--md-sys-color-secondary')
+    setThemeProperty(target, '--secondary-color-hover-solid', '--md-ref-palette-secondary70')
+    setThemeProperty(target, '--secondary-color-focus-solid', '--md-ref-palette-secondary80')
+    setThemeProperty(target, '--secondary-container-color', '--md-sys-color-secondary-container')
+    setThemeProperty(target, '--font-on-secondary-container-color', '--md-sys-color-on-secondary-container')
+
+  
+    // --md_sys_color_on-surface: 28, 27, 31;
+  }


### PR DESCRIPTION
New feature to select color scheme and generate scss token file directly from https://materializeweb.com

![imagen](https://github.com/materializecss/materialize-docs/assets/80809/8a4f3490-776a-4df0-b5e2-90186b7442ab)

There are many things that could be improved and discussed:
- color select dialog can clearly be improved
- maybe some color selector component can be used instead of this  `<input type="color">`
- it would be nice that secondary and tertiary colors could be also defined

Also, generating our own scss files opens the possibility of not to depend on tokens.module.scss. I mean, we could now generate directly the _theme_variables.scss as it was originally and avoid the use of all *.module.scss.

But I found that this tokens.module.scss  is very useful to generate pages based in M3 color system, so this should be discussed. Now the generated file is the same that we would obtain from M3 website.

My[ original idea ](https://github.com/materializecss/materialize/discussions/397#discussioncomment-6908141) was to prepare a separate, optional, library that will allow to use dinamic colors and M3 list of styles (this library will include material-foundation library and all *. module.scss stuff). But now I think that maybe just implementing this in material-docs and let the interested user follow that example would be more simple and easier to maintain.

