### PR TITLE
Fix broken code tags in navbar doc

### DIFF
--- a/navbar.html
+++ b/navbar.html
@@ -17,10 +17,8 @@
               </p>
               <h3 class="header">Right Aligned Links</h3>
               <p>
-                To right align your navbar links, just add a <code class="language-html">right</code> class to your
-                <code class="language-html">
-                  <xmp><ul></ul></xmp>
-                </code>
+                To right align your navbar links, just add a <code class="language-html">right</code> class to the
+                <code class="language-html">ul</code>
                 that contains them.
               </p>
               <nav>
@@ -61,10 +59,8 @@
             <div id="left" class="section scrollspy">
               <h3 class="header">Left Aligned Links</h3>
               <p>
-                To left align your navbar links, just add a <code class="language-html">left</code> class to your
-                <code class="language-html">
-                  <xmp><ul></ul></xmp>
-                </code>
+                To left align your navbar links, just add a <code class="language-html">left</code> class to the
+                <code class="language-html">ul</code>
                 that contains them.
               </p>
               <nav>
@@ -106,10 +102,10 @@
               <h3 class="header">Centering the logo</h3>
               <p>
                 The logo will center itself on medium and down screens, but if you want the logo to always be centered, add the <code class="language-html">center</code> class to
-                your
+                your 
                 <code class="language-html">
-                  <xmp><a class="brand-logo"></a></xmp></code
-                >. You will have to make sure yourself that links do not overlap if you use this.
+                  &lt;a class=&quot;brand-logo&quot;&gt;&lt;/a&gt;
+                </code>. You will have to make sure yourself that links do not overlap if you use this.
               </p>
               <nav>
                 <div class="nav-wrapper">


### PR DESCRIPTION
https://materializeweb.com/navbar.html

![image](https://github.com/user-attachments/assets/7714d892-4105-4dbe-8ccd-3b170dbdf283)


`xmp` tag is not taken into account if not within `pre` tag.

By the way  [xmp element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp) it is deprecated.

Instead we can easily escape html example with this kind of free formatters : https://www.freeformatter.com/html-escape.html#before-output

