### PR TITLE
updated docs for badges and collapsible

### DIFF
--- a/src/badges.html
+++ b/src/badges.html
@@ -116,13 +116,19 @@
 
                   <ul class="collapsible">
                     <li>
-                      <div class="collapsible-header"><i class="material-icons">filter_drama</i>First<span class="new badge">4</span></div>
+                      <div class="collapsible-header">
+                        <i class="material-icons">filter_drama</i>
+                        <div class="collapsible-header-content">First</div>
+                        <span class="new badge">4</span></div>
                       <div class="collapsible-body">
                         <p>Lorem ipsum dolor sit amet.</p>
                       </div>
                     </li>
                     <li>
-                      <div class="collapsible-header"><i class="material-icons">place</i>Second<span class="badge">1</span></div>
+                      <div class="collapsible-header">
+                        <i class="material-icons">place</i>
+                        <div class="collapsible-header-content">Second</div>
+                        <span class="badge">1</span></div>
                       <div class="collapsible-body">
                         <p>Lorem ipsum dolor sit amet.</p>
                       </div>
@@ -134,14 +140,14 @@
   <li>
     <div class="collapsible-header">
       <i class="material-icons">filter_drama</i>
-      First
+      <div class="collapsible-header-content">First</div>
       <span class="new badge">4</span></div>
     <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>
   <li>
     <div class="collapsible-header">
       <i class="material-icons">place</i>
-      Second
+      <div class="collapsible-header-content">Second</div>
       <span class="badge">1</span></div>
     <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>

--- a/src/badges.html
+++ b/src/badges.html
@@ -133,6 +133,15 @@
                         <p>Lorem ipsum dolor sit amet.</p>
                       </div>
                     </li>
+                    <li>
+                      <div class="collapsible-header">
+                        <i class="material-icons">textsms</i>
+                        <div class="collapsible-header-content">Third</div>
+                        <span class="badge leading new">4</span></div>
+                      <div class="collapsible-body">
+                        <p>Lorem ipsum dolor sit amet.</p>
+                      </div>
+                    </li>
                   </ul>
                   <pre><code class="language-html">
 <xmp>
@@ -149,6 +158,13 @@
       <i class="material-icons">place</i>
       <div class="collapsible-header-content">Second</div>
       <span class="badge">1</span></div>
+    <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
+  </li>
+  <li>
+    <div class="collapsible-header">
+      <i class="material-icons">textsms</i>
+      <div class="collapsible-header-content">Third</div>
+      <span class="badge new">4</span></div>
     <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>
 </ul>

--- a/src/collapsible.html
+++ b/src/collapsible.html
@@ -22,13 +22,13 @@
                 <div class="collapsible-header-content">First</div>
               </div>
               <div class="collapsible-body">
-                <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
                   commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                   ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
                   ut aliquip ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                   tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                  ullamco laboris nisi ut aliquip ex ea commodo consequat.</span>
+                  ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
               </div>
             </li>
             <li>
@@ -37,9 +37,9 @@
                 <div class="collapsible-header-content">Second</div>
               </div>
               <div class="collapsible-body">
-                <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-                  commodo consequat.</span>
+                  commodo consequat.</p>
               </div>
             </li>
             <li>
@@ -48,9 +48,9 @@
                 <div class="collapsible-header-content">Third</div>
               </div>
               <div class="collapsible-body">
-                <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-                  commodo consequat.</span>
+                  commodo consequat.</p>
               </div>
             </li>
           </ul>
@@ -64,15 +64,15 @@
 <ul class="collapsible">
   <li>
     <div class="collapsible-header"><i class="material-icons">filter_drama</i>First</div>
-    <div class="collapsible-body"><span>Lorem ipsum dolor sit amet.</span></div>
+    <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>
   <li>
     <div class="collapsible-header"><i class="material-icons">place</i>Second</div>
-    <div class="collapsible-body"><span>Lorem ipsum dolor sit amet.</span></div>
+    <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>
   <li>
     <div class="collapsible-header"><i class="material-icons">whatshot</i>Third</div>
-    <div class="collapsible-body"><span>Lorem ipsum dolor sit amet.</span></div>
+    <div class="collapsible-body"><p>Lorem ipsum dolor sit amet.</p></div>
   </li>
 </ul>
 </xmp>
@@ -104,33 +104,33 @@
             <div class="collapsible-header">
               <i class="material-icons">filter_drama</i>First</div>
             <div class="collapsible-body">
-              <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
                 et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
                 ex ea commodo consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
                 ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
-                ut aliquip ex ea commodo consequat.</span>
+                ut aliquip ex ea commodo consequat.</p>
             </div>
           </li>
           <li class="active">
             <div class="collapsible-header">
               <i class="material-icons">place</i>Second</div>
             <div class="collapsible-body">
-              <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat.
-              </span>
+              </p>
             </div>
           </li>
           <li>
             <div class="collapsible-header">
               <i class="material-icons">whatshot</i>Third</div>
             <div class="collapsible-body">
-              <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat.
-              </span>
+              </p>
             </div>
           </li>
         </ul>

--- a/src/collapsible.html
+++ b/src/collapsible.html
@@ -18,7 +18,9 @@
           <ul class="collapsible collapsible-accordion">
             <li>
               <div class="collapsible-header">
-                <i class="material-icons">filter_drama</i>First</div>
+                <i class="material-icons">filter_drama</i>
+                <div class="collapsible-header-content">First</div>
+              </div>
               <div class="collapsible-body">
                 <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -31,7 +33,9 @@
             </li>
             <li>
               <div class="collapsible-header">
-                <i class="material-icons">place</i>Second</div>
+                <i class="material-icons">place</i>
+                <div class="collapsible-header-content">Second</div>
+              </div>
               <div class="collapsible-body">
                 <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -40,7 +44,9 @@
             </li>
             <li>
               <div class="collapsible-header">
-                <i class="material-icons">whatshot</i>Third</div>
+                <i class="material-icons">whatshot</i>
+                <div class="collapsible-header-content">Third</div>
+              </div>
               <div class="collapsible-body">
                 <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                   magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea


### PR DESCRIPTION
updated docs for badges and collapsible, implemented corresponding collapsible header content wrapper

before
<img width="744" alt="Screenshot 2024-12-29 at 14 21 57" src="https://github.com/user-attachments/assets/75c0f7dd-108d-40a0-813d-f47c80431965" />

after
<img width="745" alt="Screenshot 2024-12-29 at 14 35 32" src="https://github.com/user-attachments/assets/7ff881a0-327d-4c7e-b200-b605751697dc" />
