### PR TITLE
fix: missing start tag h5 for method header in sidenav.html

### DIFF
--- a/src/sidenav.html
+++ b/src/sidenav.html
@@ -195,7 +195,7 @@ instance.open();
         </code></pre>
         
 
-        class="method-header">
+        <h5 class="method-header">
           .close();
         </h5>
         <p>Closes Sidenav.</p>
@@ -204,7 +204,7 @@ instance.close();
         </code></pre>
         
 
-        class="method-header">
+        <h5 class="method-header">
           .destroy();
         </h5>
         <p>Destroy plugin instance and teardown</p>


### PR DESCRIPTION
Start tag `h5` in Sidenav documentation page (`sidenav.html`) ismissing.

**Before**:
![image](https://github.com/user-attachments/assets/8a524dbe-af68-4741-9c32-20d05564fadc)


**After**:
![image](https://github.com/user-attachments/assets/626ec73a-585e-4bff-a024-aab128c673cb)
